### PR TITLE
Added mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ Currently added widgets below.
 
 ## Paragraph  
 
-Added but no modifications yet
+The custom Paragraph widget is almost exactly the same, but features the
+"scroll_consider_wrap" field & function. See it's function for what it does.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Modified widgets the [Ratatui](https://ratatui.rs/) library.
+//! Modified widgets of the [Ratatui](https://ratatui.rs/) library.
 
 /// Custom widgets, mostly a mirror of ratatui's
 pub mod widgets;

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -51,8 +51,10 @@ pub struct Paragraph<'a> {
     scroll: (u16, u16),
     /// Alignment of the text
     alignment: Alignment,
-    /// Whether to consider the wrap
-    scroll_consider_wrap: bool,
+    /// How to hand scroll when wrap is enabled
+    ///
+    /// See the [`Paragraph::scroll_consider_wrap`] function
+    scroll_consider_wrap: bool, // NOTE: maybe move to Wrap
 }
 
 /// Describes how to wrap text across lines.
@@ -194,7 +196,27 @@ impl<'a> Paragraph<'a> {
 
     /// Set whether scroll considers wrap
     ///
-    /// When this is false, scroll may undershoot the correct line
+    /// When this is false, scroll may undershoot the correct line.
+    ///
+    /// For example if you had:
+    ///
+    /// 1. ...Long text...
+    /// 2. ...
+    /// 3. ...Long text...
+    /// 4. ...
+    ///
+    /// Which would wrap to:
+    ///
+    /// 1.1. ...
+    /// 1.2. ...
+    /// 2.   ...
+    /// 3.1. ...
+    /// 3.2. ...
+    /// 3.3. ...
+    /// 4.   ...
+    ///
+    /// With a scroll of `(3,0)`, the normal behavior would get you to
+    /// '3.1', with `scroll_consider_wrap` enabled, you instead get to '4'
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn scroll_consider_wrap(mut self, scroll_consider_wrap: bool) -> Self {
         self.scroll_consider_wrap = scroll_consider_wrap;

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -51,6 +51,8 @@ pub struct Paragraph<'a> {
     scroll: (u16, u16),
     /// Alignment of the text
     alignment: Alignment,
+    /// Whether to consider the wrap
+    scroll_consider_wrap: bool,
 }
 
 /// Describes how to wrap text across lines.
@@ -118,6 +120,7 @@ impl<'a> Paragraph<'a> {
             text: text.into(),
             scroll: (0, 0),
             alignment: Alignment::Left,
+            scroll_consider_wrap: false,
         }
     }
 
@@ -186,6 +189,15 @@ impl<'a> Paragraph<'a> {
     #[must_use = "method moves the value of self and returns the modified value"]
     pub const fn scroll(mut self, offset: (Vertical, Horizontal)) -> Self {
         self.scroll = offset;
+        self
+    }
+
+    /// Set whether scroll considers wrap
+    ///
+    /// When this is false, scroll may undershoot the correct line
+    #[must_use = "method moves the value of self and returns the modified value"]
+    pub const fn scroll_consider_wrap(mut self, scroll_consider_wrap: bool) -> Self {
+        self.scroll_consider_wrap = scroll_consider_wrap;
         self
     }
 
@@ -362,14 +374,19 @@ impl Paragraph<'_> {
 impl<'a> Paragraph<'a> {
     fn render_text<C: LineComposer<'a>>(&self, mut composer: C, area: Rect, buf: &mut Buffer) {
         let mut y = 0;
+        let mut scroll_offset = self.scroll.0;
+
         while let Some(WrappedLine {
             line: current_line,
             width: current_line_width,
             alignment: current_line_alignment,
-            wrapped,
+            wraps,
         }) = composer.next_line()
         {
-            if y >= self.scroll.0 {
+            if wraps != 0 && y < scroll_offset && self.scroll_consider_wrap {
+                scroll_offset += wraps;
+            } // NOTE: maybe use arithmetic instead of if
+            if y >= scroll_offset {
                 let mut x = get_line_offset(current_line_width, area.width, current_line_alignment);
                 for StyledGrapheme { symbol, style } in current_line {
                     let width = symbol.width();
@@ -379,14 +396,14 @@ impl<'a> Paragraph<'a> {
                     // If the symbol is empty, the last char which rendered last time will
                     // leave on the line. It's a quick fix.
                     let symbol = if symbol.is_empty() { " " } else { symbol };
-                    buf.get_mut(area.left() + x, area.top() + y - self.scroll.0)
+                    buf.get_mut(area.left() + x, area.top() + y - scroll_offset)
                         .set_symbol(symbol)
                         .set_style(*style);
                     x += width as u16;
                 }
             }
-            y += 1 + wrapped as u16;
-            if y >= area.height + self.scroll.0 {
+            y += 1;
+            if y >= area.height + scroll_offset {
                 break;
             }
         }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -366,7 +366,7 @@ impl<'a> Paragraph<'a> {
             line: current_line,
             width: current_line_width,
             alignment: current_line_alignment,
-            wrapped: _,
+            wrapped,
         }) = composer.next_line()
         {
             if y >= self.scroll.0 {
@@ -385,7 +385,7 @@ impl<'a> Paragraph<'a> {
                     x += width as u16;
                 }
             }
-            y += 1;
+            y += 1 + wrapped as u16;
             if y >= area.height + self.scroll.0 {
                 break;
             }

--- a/src/widgets/paragraph.rs
+++ b/src/widgets/paragraph.rs
@@ -366,6 +366,7 @@ impl<'a> Paragraph<'a> {
             line: current_line,
             width: current_line_width,
             alignment: current_line_alignment,
+            wrapped: _,
         }) = composer.next_line()
         {
             if y >= self.scroll.0 {

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -21,6 +21,8 @@ pub struct WrappedLine<'lend, 'text> {
     pub width: u16,
     /// Whether the line was aligned left or right
     pub alignment: Alignment,
+    /// Whether the line has been wrapped or not
+    pub wrapped: bool,
 }
 
 /// A state machine that wraps lines on word boundaries.
@@ -217,6 +219,7 @@ where
                 line: &self.current_line,
                 width: line_width,
                 alignment: self.current_alignment,
+                wrapped: self.wrapped_lines.is_some(),
             })
         } else {
             None
@@ -317,6 +320,7 @@ where
                 line: &self.current_line,
                 width: current_line_width,
                 alignment: current_alignment,
+                wrapped: false,
             })
         }
     }
@@ -379,6 +383,7 @@ mod test {
             line: styled,
             width,
             alignment,
+            ..
         }) = composer.next_line()
         {
             let line = styled

--- a/src/widgets/reflow.rs
+++ b/src/widgets/reflow.rs
@@ -21,8 +21,11 @@ pub struct WrappedLine<'lend, 'text> {
     pub width: u16,
     /// Whether the line was aligned left or right
     pub alignment: Alignment,
-    /// Whether the line has been wrapped or not
-    pub wrapped: bool,
+    /// Number of times this line was wrapped
+    ///
+    /// If n = 0, this line was not wrapped. If n != 0,
+    /// the next n lines were part of this line
+    pub wraps: u16,
 }
 
 /// A state machine that wraps lines on word boundaries.
@@ -75,6 +78,8 @@ where
 
         let mut current_line: Option<Vec<StyledGrapheme<'a>>> = None;
         let mut line_width: u16 = 0;
+
+        let mut wraps = 0;
 
         // Try to repeatedly retrieve next line
         while current_line.is_none() {
@@ -147,6 +152,7 @@ where
                             // or if it would be too long with the current partially processed word added
                             || current_line_width + whitespace_width + word_width >= self.max_line_width && symbol_width > 0
                         {
+                            wraps += 1;
                             let mut remaining_width = (i32::from(self.max_line_width)
                                 - i32::from(current_line_width))
                             .max(0) as u16;
@@ -219,7 +225,7 @@ where
                 line: &self.current_line,
                 width: line_width,
                 alignment: self.current_alignment,
-                wrapped: self.wrapped_lines.is_some(),
+                wraps,
             })
         } else {
             None
@@ -320,7 +326,7 @@ where
                 line: &self.current_line,
                 width: current_line_width,
                 alignment: current_alignment,
-                wrapped: false,
+                wraps: 0,
             })
         }
     }

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -1,0 +1,367 @@
+use ratatui::{
+    backend::TestBackend,
+    buffer::Buffer,
+    layout::Alignment,
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, Padding, Paragraph, Wrap},
+    Terminal,
+};
+
+/// Tests the [`Paragraph`] widget against the expected [`Buffer`] by rendering it onto an equal
+/// area and comparing the rendered and expected content.
+#[allow(clippy::needless_pass_by_value)]
+fn test_case(paragraph: Paragraph, expected: Buffer) {
+    let backend = TestBackend::new(expected.area.width, expected.area.height);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            f.render_widget(paragraph, size);
+        })
+        .unwrap();
+
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_paragraph_renders_double_width_graphemes() {
+    let s = "コンピュータ上で文字を扱う場合、典型的には文字による通信を行う場合にその両端点では、";
+
+    let text = vec![Line::from(s)];
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap { trim: true });
+
+    test_case(
+        paragraph,
+        Buffer::with_lines(vec![
+            "┌────────┐",
+            "│コンピュ│",
+            "│ータ上で│",
+            "│文字を扱│",
+            "│う場合、│",
+            "│典型的に│",
+            "│は文字に│",
+            "│よる通信│",
+            "│を行う場│",
+            "└────────┘",
+        ]),
+    );
+}
+
+#[test]
+fn widgets_paragraph_renders_mixed_width_graphemes() {
+    let backend = TestBackend::new(10, 7);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    let s = "aコンピュータ上で文字を扱う場合、";
+    terminal
+        .draw(|f| {
+            let size = f.size();
+            let text = vec![Line::from(s)];
+            let paragraph = Paragraph::new(text)
+                .block(Block::default().borders(Borders::ALL))
+                .wrap(Wrap { trim: true });
+            f.render_widget(paragraph, size);
+        })
+        .unwrap();
+
+    let expected = Buffer::with_lines(vec![
+        // The internal width is 8 so only 4 slots for double-width characters.
+        "┌────────┐",
+        "│aコンピ │", // Here we have 1 latin character so only 3 double-width ones can fit.
+        "│ュータ上│",
+        "│で文字を│",
+        "│扱う場合│",
+        "│、      │",
+        "└────────┘",
+    ]);
+    terminal.backend().assert_buffer(&expected);
+}
+
+#[test]
+fn widgets_paragraph_can_wrap_with_a_trailing_nbsp() {
+    let nbsp = "\u{00a0}";
+    let line = Line::from(vec![Span::raw("NBSP"), Span::raw(nbsp)]);
+    let paragraph = Paragraph::new(line).block(Block::default().borders(Borders::ALL));
+
+    test_case(
+        paragraph,
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│NBSP\u{00a0}             │",
+            "└──────────────────┘",
+        ]),
+    );
+}
+
+#[test]
+fn widgets_paragraph_can_scroll_horizontally() {
+    let text =
+        Text::from("段落现在可以水平滚动了！\nParagraph can scroll horizontally!\nLittle line");
+    let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::ALL));
+
+    test_case(
+        paragraph.clone().alignment(Alignment::Left).scroll((0, 7)),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│在可以水平滚动了！│",
+            "│ph can scroll hori│",
+            "│line              │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+    // only support Alignment::Left
+    test_case(
+        paragraph.clone().alignment(Alignment::Right).scroll((0, 7)),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│段落现在可以水平滚│",
+            "│Paragraph can scro│",
+            "│       Little line│",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+}
+
+const SAMPLE_STRING: &str = "The library is based on the principle of immediate rendering with \
+     intermediate buffers. This means that at each new frame you should build all widgets that are \
+     supposed to be part of the UI. While providing a great flexibility for rich and \
+     interactive UI, this may introduce overhead for highly dynamic content.";
+
+#[test]
+fn widgets_paragraph_can_wrap_its_content() {
+    let text = vec![Line::from(SAMPLE_STRING)];
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap { trim: true });
+
+    test_case(
+        paragraph.clone().alignment(Alignment::Left),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│The library is    │",
+            "│based on the      │",
+            "│principle of      │",
+            "│immediate         │",
+            "│rendering with    │",
+            "│intermediate      │",
+            "│buffers. This     │",
+            "│means that at each│",
+            "└──────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.clone().alignment(Alignment::Center),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│  The library is  │",
+            "│   based on the   │",
+            "│   principle of   │",
+            "│     immediate    │",
+            "│  rendering with  │",
+            "│   intermediate   │",
+            "│   buffers. This  │",
+            "│means that at each│",
+            "└──────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.clone().alignment(Alignment::Right),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│    The library is│",
+            "│      based on the│",
+            "│      principle of│",
+            "│         immediate│",
+            "│    rendering with│",
+            "│      intermediate│",
+            "│     buffers. This│",
+            "│means that at each│",
+            "└──────────────────┘",
+        ]),
+    );
+}
+
+#[test]
+fn widgets_paragraph_works_with_padding() {
+    let text = vec![Line::from(SAMPLE_STRING)];
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL).padding(Padding {
+            left: 2,
+            right: 2,
+            top: 1,
+            bottom: 1,
+        }))
+        .wrap(Wrap { trim: true });
+
+    test_case(
+        paragraph.clone().alignment(Alignment::Left),
+        Buffer::with_lines(vec![
+            "┌────────────────────┐",
+            "│                    │",
+            "│  The library is    │",
+            "│  based on the      │",
+            "│  principle of      │",
+            "│  immediate         │",
+            "│  rendering with    │",
+            "│  intermediate      │",
+            "│  buffers. This     │",
+            "│  means that at     │",
+            "│                    │",
+            "└────────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.clone().alignment(Alignment::Right),
+        Buffer::with_lines(vec![
+            "┌────────────────────┐",
+            "│                    │",
+            "│    The library is  │",
+            "│      based on the  │",
+            "│      principle of  │",
+            "│         immediate  │",
+            "│    rendering with  │",
+            "│      intermediate  │",
+            "│     buffers. This  │",
+            "│     means that at  │",
+            "│                    │",
+            "└────────────────────┘",
+        ]),
+    );
+
+    let mut text = vec![Line::from("This is always centered.").alignment(Alignment::Center)];
+    text.push(Line::from(SAMPLE_STRING));
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL).padding(Padding {
+            left: 2,
+            right: 2,
+            top: 1,
+            bottom: 1,
+        }))
+        .wrap(Wrap { trim: true });
+
+    test_case(
+        paragraph.alignment(Alignment::Right),
+        Buffer::with_lines(vec![
+            "┌────────────────────┐",
+            "│                    │",
+            "│   This is always   │",
+            "│      centered.     │",
+            "│    The library is  │",
+            "│      based on the  │",
+            "│      principle of  │",
+            "│         immediate  │",
+            "│    rendering with  │",
+            "│      intermediate  │",
+            "│     buffers. This  │",
+            "│     means that at  │",
+            "│                    │",
+            "└────────────────────┘",
+        ]),
+    );
+}
+
+#[test]
+fn widgets_paragraph_can_align_spans() {
+    let right_s = "This string will override the paragraph alignment to be right aligned.";
+    let default_s = "This string will be aligned based on the alignment of the paragraph.";
+
+    let text = vec![
+        Line::from(right_s).alignment(Alignment::Right),
+        Line::from(default_s),
+    ];
+    let paragraph = Paragraph::new(text)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap { trim: true });
+
+    test_case(
+        paragraph.clone().alignment(Alignment::Left),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│  This string will│",
+            "│      override the│",
+            "│         paragraph│",
+            "│   alignment to be│",
+            "│    right aligned.│",
+            "│This string will  │",
+            "│be aligned based  │",
+            "│on the alignment  │",
+            "└──────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.alignment(Alignment::Center),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│  This string will│",
+            "│      override the│",
+            "│         paragraph│",
+            "│   alignment to be│",
+            "│    right aligned.│",
+            "│ This string will │",
+            "│ be aligned based │",
+            "│ on the alignment │",
+            "└──────────────────┘",
+        ]),
+    );
+
+    let left_lines = vec!["This string", "will override the paragraph alignment"]
+        .into_iter()
+        .map(|s| Line::from(s).alignment(Alignment::Left))
+        .collect::<Vec<_>>();
+    let mut lines = vec![
+        "This",
+        "must be pretty long",
+        "in order to effectively show",
+        "truncation.",
+    ]
+    .into_iter()
+    .map(Line::from)
+    .collect::<Vec<_>>();
+
+    let mut text = left_lines.clone();
+    text.append(&mut lines);
+    let paragraph = Paragraph::new(text).block(Block::default().borders(Borders::ALL));
+
+    test_case(
+        paragraph.clone().alignment(Alignment::Right),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│This string       │",
+            "│will override the │",
+            "│              This│",
+            "│must be pretty lon│",
+            "│in order to effect│",
+            "│       truncation.│",
+            "│                  │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+    test_case(
+        paragraph.alignment(Alignment::Left),
+        Buffer::with_lines(vec![
+            "┌──────────────────┐",
+            "│This string       │",
+            "│will override the │",
+            "│This              │",
+            "│must be pretty lon│",
+            "│in order to effect│",
+            "│truncation.       │",
+            "│                  │",
+            "└──────────────────┘",
+        ]),
+    );
+}

--- a/tests/widgets_paragraph.rs
+++ b/tests/widgets_paragraph.rs
@@ -1,9 +1,10 @@
+use flc_tui_widgets::widgets::{Paragraph, Wrap};
 use ratatui::{
     backend::TestBackend,
     buffer::Buffer,
     layout::Alignment,
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Padding, Paragraph, Wrap},
+    widgets::{Block, Borders, Padding},
     Terminal,
 };
 


### PR DESCRIPTION
Added modifications to Paragraph struct, custom wrap & scrolling behaviour added. 

New feature enables user to scroll by "inputted" lines(new behaviour), rather than "wrapped" lines(normal behaviour).
This leads to behaviour closer to a text editor, for example Neovim.

There are still a few things to sort out: 

- whether this behaviour should be set from the Wrap struct.
- how this feature should be named